### PR TITLE
Tratamento de erro --package

### DIFF
--- a/src/dpm/cli.py
+++ b/src/dpm/cli.py
@@ -69,8 +69,6 @@ def cli_install(
             return 1
     extract_source_packages(data_toml, output_dir)
 
-    extract_source_packages(data_toml, output_dir)
-
 
 @app.command("load")
 def cli_load(

--- a/src/dpm/cli.py
+++ b/src/dpm/cli.py
@@ -60,6 +60,14 @@ def cli_install(
     # filter data_toml based in the packages option list
     if package:
         data_toml = {"packages": {name: pkg for name, pkg in data_toml["packages"].items() if name in package}}
+        available_packages = set(data_toml["packages"].keys())
+        selected_packages = set(package)
+        missing_packages = list(selected_packages - available_packages)
+
+        if missing_packages:
+            print(f"'{', '.join(missing_packages)}' did not match any packages in your data.toml. Interrupting.")
+            return 1
+    extract_source_packages(data_toml, output_dir)
 
     extract_source_packages(data_toml, output_dir)
 

--- a/src/dpm/utils.py
+++ b/src/dpm/utils.py
@@ -6,7 +6,7 @@ def as_identifier(x, case=str.lower):
     result = unidecode(x) 
     result = re.sub(r'\([^)]*\)', '', result)  # Remove all characters within parentheses
     result = result.replace('\u00a0', ' ')  # Replace non-breaking space with regular space
-    result = re.sub('\W|^(?=\d)','_', result)
+    result = re.sub(r'\W|^(?=\d)','_', result)
     result = re.sub('_+', '_', result)
     result = case(result)
     return result.strip('_')


### PR DESCRIPTION
closes #81 
* Adiciona tratamento de erro ao utilizar nomes inválidos de pacotes na opção `--package`
* caso um dos nomes de pacote passado como parâmetro não esteja presente no `data.toml`, a execução é interrompida e mensagem de erro exibida.